### PR TITLE
fix: better phone number handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,9 @@ module.exports = {
   },
   // this ignores everything from being transformed in node_modules except for the compromise module
   transformIgnorePatterns: ["node_modules/(?!compromise)/"],
+  globals: {
+    navigator: {
+      language: "de-CH",
+    },
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "lakera",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lakera",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "hasInstallScript": true,
       "dependencies": {
         "addresser": "^1.1.20",
         "compromise": "^14.9.0",
+        "libphonenumber-js": "^1.10.55",
         "luhn": "^2.4.1",
-        "phone": "^3.1.37",
         "sweetalert2": "^11.7.20"
       },
       "devDependencies": {
@@ -8593,6 +8593,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.55",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.55.tgz",
+      "integrity": "sha512-MrTg2JFLscgmTY6/oT9vopYETlgUls/FU6OaeeamGwk4LFxjIgOUML/ZSZICgR0LPYXaonVJo40lzMvaaTJlQA=="
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -9202,14 +9207,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/phone": {
-      "version": "3.1.39",
-      "resolved": "https://registry.npmjs.org/phone/-/phone-3.1.39.tgz",
-      "integrity": "sha512-+9ON+0aIh7Ax9C/3od2jZBA+przhtixdBYZxKME5DwFcpGVW3XQAQXLYIvFr8AMUI8Zr6o1Mj3kkY35B0AvQVw==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "addresser": "^1.1.20",
     "compromise": "^14.9.0",
+    "libphonenumber-js": "^1.10.55",
     "luhn": "^2.4.1",
-    "phone": "^3.1.37",
     "sweetalert2": "^11.7.20"
   },
   "devDependencies": {

--- a/src/__tests__/detectors_tests/isPhoneNumber.test.ts
+++ b/src/__tests__/detectors_tests/isPhoneNumber.test.ts
@@ -1,5 +1,35 @@
 import { isPhoneNumber } from '../../prompt'
 
+// some extra test case numbers from Phone Number
+// GitHub Issue: https://github.com/lakeraai/chrome-extension/issues/1
+const testNumbersUS = [
+  '+1 (617) 867-5309',
+  '+1-617-867-5309',
+  '+1.617.867.5309',
+  '+1 617 867 5309',
+  '617-867-5309',
+  '617.867.5309',
+  '617 867 5309',
+  '(617) 867-5309',
+  '00(617) 867-5309'
+]
+
+// some formats that are just kind of broken and hard to parse
+const testNonNumbersUS = ['00617 867 5309', '00617-867-5309', '00617.867.5309']
+
+// we'll default to the Swiss locale for these tests
+const navigator = { language: 'de-CH' }
+
+Object.defineProperty(globalThis, 'navigator', {
+  value: navigator,
+  writable: true,
+  configurable: true
+})
+
+afterEach(() => {
+  navigator.language = 'de-CH'
+})
+
 describe('Phone numbers', () => {
   describe('True positives', () => {
     test('phone number with 41 country code', () => {
@@ -49,27 +79,34 @@ describe('Phone numbers', () => {
     test('phone number with +41 country code and in context', () => {
       expect(isPhoneNumber('I texted my friend at +41747587256').pii).toBe(true)
     })
+
+    describe('US phone number with dashes instead of parentheses', () => {
+      test('user locale is CH', () => {
+        expect(isPhoneNumber('617-867-5309').pii).toBe(true)
+      })
+
+      test('user locale is US', () => {
+        navigator.language = 'en-US'
+        expect(isPhoneNumber('617-867-5309').pii).toBe(true)
+      })
+    })
+
+    describe('Extra test cases', () => {
+      test.each(testNumbersUS)('Test: %s', (num) => {
+        navigator.language = 'en-US'
+        expect(isPhoneNumber(num).pii).toBe(true)
+      })
+
+      test.each(testNonNumbersUS)('Test: %s', (num) => {
+        navigator.language = 'en-US'
+        expect(isPhoneNumber(num).pii).toBe(false)
+      })
+    })
   })
 
   describe('False positives', () => {})
 
   describe('True negatives', () => {
-    test('phone number with less than 11 digits', () => {
-      expect(isPhoneNumber('+4174758725').pii).toBe(false)
-    })
-
-    test('phone number without country code', () => {
-      expect(isPhoneNumber('747587256').pii).toBe(false)
-    })
-
-    test('phone number with 41 country code and random characters', () => {
-      expect(isPhoneNumber('41 asdadsa-747-587-256').pii).toBe(false)
-    })
-
-    test('phone number with +41 country code and random characters', () => {
-      expect(isPhoneNumber('+41 asdadsa-747-587-256').pii).toBe(false)
-    })
-
     test('phone number with split digits', () => {
       expect(
         isPhoneNumber(
@@ -79,5 +116,21 @@ describe('Phone numbers', () => {
     })
   })
 
-  describe('False negatives', () => {})
+  describe('Edge cases', () => {
+    test('Swiss phone number with 41 country code and random characters', () => {
+      expect(isPhoneNumber('41 asdadsa-747-587-256').pii).toBe(true)
+    })
+
+    test('phone number with +41 country code and random characters', () => {
+      expect(isPhoneNumber('+41 asdadsa-747-587-256').pii).toBe(true)
+    })
+
+    test('phone number without country code', () => {
+      expect(isPhoneNumber('747587256').pii).toBe(true)
+    })
+
+    test('phone number with less than 11 digits', () => {
+      expect(isPhoneNumber('+4174758725').pii).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
This adds improved phone number detection via [`libphonenumber-js`](https://github.com/catamphetamine/libphonenumber-js) which is based on [`google/libphonenumber`](https://github.com/google/libphonenumber).

It also adds support for displaying multiple phone numbers if they are detected.

**Note**: There are still some challenges around international phone numbers without the preceding `+` but we now try to use the browser's locale to set the expected country code and then also use the `US` country code to try to maximize detected phone numbers.

**Example of Multiple Phone Numbers Detected*:

<img width="1135" alt="Screenshot 2024-02-08 at 5 03 42 PM" src="https://github.com/lakeraai/chrome-extension/assets/1667415/f06955b9-eaf2-432d-a6a4-e47652e1d75f">
